### PR TITLE
Better logout

### DIFF
--- a/integration_tests/test_uaa.py
+++ b/integration_tests/test_uaa.py
@@ -116,9 +116,8 @@ def test_reset_totp(authenticated, user):
     assert r.status_code == 200
 
     # reset-totp is supposed to log a user out. Logging in should reset our totp
-    token, changed = r.log_in(user["name"], user["password"])
+    token, changed = authenticated.log_in(user["name"], user["password"])
     assert changed
-    os.environ["TEST_TOKEN"] = token
 
 
 @pytest.mark.parametrize("page", ["/invite", "/change-password"])

--- a/uaaextras/templates/reset_totp.html
+++ b/uaaextras/templates/reset_totp.html
@@ -6,10 +6,7 @@
 
 {% block content %}
 <div class="island-content">
-    {% if reset_complete %}
-    <p>Your MFA token has been reset and you have been logged out. To register a new token, please <a href="{{login_link}}">log in</a> again.</p>
-    {% else %}
-    <p>You can reset your MFA token here. Doing so will deactivate your currently registered MFA token, and require you to register a new token on your next login.</p>
+    <p>You can reset your MFA token here. Doing so will deactivate your currently registered MFA token, log you out, and require you to register a new token on your next login.</p>
     <form action="{{ url_for('reset_totp') }}" method="post">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
         <input class="island-button" type="submit" value="Reset MFA">

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -742,6 +742,7 @@ def create_app(env=os.environ):
         g.totp.unset_totp_seed(username)
         g.uaac.invalidate_tokens(decoded_token['user_id'])
         session.clear()
+        return redirect(app.config['UAA_BASE_URL'] + '/logout.do')
         return render_template("reset_totp.html", login_link=app.config['UAA_BASE_URL'], reset_complete=True)
 
     @app.route('/logout')

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -743,7 +743,6 @@ def create_app(env=os.environ):
         g.uaac.invalidate_tokens(decoded_token['user_id'])
         session.clear()
         return redirect(app.config['UAA_BASE_URL'] + '/logout.do')
-        return render_template("reset_totp.html", login_link=app.config['UAA_BASE_URL'], reset_complete=True)
 
     @app.route('/logout')
     def logout():


### PR DESCRIPTION
## Changes proposed in this pull request:
- log users out better
- correct some calls in tests

Currently, we are attempting to log out by invalidating uaa tokens and clearing the session. The user still has their cookies from Shibboleth, though, so hitting the login endpoint routes them through without auth. 
By instead redirecting them to the logout, shibboleth cleans up its cookies

## security considerations
None