### PR TITLE
Log in users with bad tokens

### DIFF
--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -797,7 +797,7 @@ def create_app(env=os.environ):
             decoded_token = g.uaac.decode_access_token(token)
             user = g.uaac.get_user(decoded_token["user_id"])
         except:
-            return redirect(app.config['UAA_BASE_URL'])
+            return redirect(app.config["UAA_BASE_URL"])
 
         if user["origin"] != app.config["IDP_PROVIDER_ORIGIN"]:
             return redirect(url_for("index"))

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -795,11 +795,10 @@ def create_app(env=os.environ):
         token = session.get("UAA_TOKEN", None)
         try:
             decoded_token = g.uaac.decode_access_token(token)
+            user = g.uaac.get_user(decoded_token["user_id"])
         except:
-            logging.exception("An invalid access token was decoded")
-            return render_template("error/token_validation.html"), 401
+            return redirect(app.config['UAA_BASE_URL'])
 
-        user = g.uaac.get_user(decoded_token["user_id"])
         if user["origin"] != app.config["IDP_PROVIDER_ORIGIN"]:
             return redirect(url_for("index"))
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- redirect users with bad tokens to login. This is a short-term workaround, as users are still not redirected _back_ to the reset endpoint. 

## security considerations
None