### PR TITLE
Add steps and reference to docs into email reset template

### DIFF
--- a/uaaextras/templates/email/body-password.html
+++ b/uaaextras/templates/email/body-password.html
@@ -16,24 +16,41 @@
         <ol>
             <li>
                 Verify your email using this link <a href="{{reset.verifyLink}}">{{reset.verifyLink}}</a>
+                to take you to the reset password verification page.
             </li>
             <li>
-                Enter your email address into the reset password verification page
+                Enter your email address in the
+                <code>Email address</code>
+                input on the reset password verification page and click
+                <em>VERIFY EMAIL</em>
             </li>
             <li>
-                Your email is verified and then copy/save the temporary, generated password.
+                Your email is verified and then copy/save the temporary password under the
+                <code>Your temporary password</code>.
             </li>
             <li>
-                <a href="https://login.fr.cloud.gov/">Login to your cloud.gov account</a> with the new temporary password
+                Login to your cloud.gov account at
+                <a href="https://login.fr.cloud.gov/">https://login.fr.cloud.gov</a>
+                with the new temporary password
             </li>
             <li>
-                After you log in, you change your temporary password using this link <a href="{{password.changeLink}}">{{password.changeLink}}</a>.
-            </li>
-            <li>
-                Enter the temporary password into the "Old Password" field
-            </li>
-            <li>
-                Then create and enter the new password into "New Password" and confirm it in the "Repeat New Password" fields
+                After logging in, go to
+                <a href="https://account.fr.cloud.gov/change-password">https://account.fr.cloud.gov/change-password</a>
+                to change the password
+                <ol>
+                    <li>
+                        Enter the temporary password into the
+                        <code>Old Password</code> input
+                    </li>
+                    <li>
+                        Then create and enter the new password into
+                        <code>New Password</code> input and confirm
+                        it in the <code>Repeat New Password</code> input
+                    </li>
+                    <li>
+                        Finally, click <em>CHANGE</em>
+                    </li>
+                </ol>
             </li>
         </ol>
         </p>

--- a/uaaextras/templates/email/body-password.html
+++ b/uaaextras/templates/email/body-password.html
@@ -15,12 +15,33 @@
         <p>
         <ol>
             <li>
-                Verify your email using this link <a href="{{reset.verifyLink}}">{{reset.verifyLink}}</a>, and follow those instructions to generate your temporary password. Save your generated password before following the next step to log in with that password.
+                Verify your email using this link <a href="{{reset.verifyLink}}">{{reset.verifyLink}}</a>
             </li>
             <li>
-                After you log in, you can change your password using this link <a href="{{password.changeLink}}">{{password.changeLink}}</a>.
+                Enter your email address into the reset password verification page
+            </li>
+            <li>
+                Your email is verified and then copy/save the temporary, generated password.
+            </li>
+            <li>
+                <a href="https://login.fr.cloud.gov/">Login to your cloud.gov account</a> with the new temporary password
+            </li>
+            <li>
+                After you log in, you change your temporary password using this link <a href="{{password.changeLink}}">{{password.changeLink}}</a>.
+            </li>
+            <li>
+                Enter the temporary password into the "Old Password" field
+            </li>
+            <li>
+                Then create and enter the new password into "New Password" and confirm it in the "Repeat New Password" fields
             </li>
         </ol>
+        </p>
+        <p>
+            More information on accounts is available in our
+            <a href="https://cloud.gov/docs/getting-started/accounts/#log-into-cloudgov">
+                documentation
+            </a>.
         </p>
         <p>
             If you run into problems or have any questions,

--- a/uaaextras/templates/email/body-password.html
+++ b/uaaextras/templates/email/body-password.html
@@ -63,8 +63,7 @@
         <p>
             If you run into problems or have any questions,
             please email us at
-            <a href="mailto:support@cloud.gov">support@cloud.gov</a>
-            <a href="mailto:cloud-gov-support@gsa.gov">cloud-gov-support@gsa.gov</a>.
+            <a href="mailto:support@cloud.gov">support@cloud.gov</a>.
         </p>
         <p>
             Thank you,<br />

--- a/uaaextras/templates/email/body-password.html
+++ b/uaaextras/templates/email/body-password.html
@@ -46,6 +46,7 @@
         <p>
             If you run into problems or have any questions,
             please email us at
+            <a href="mailto:support@cloud.gov">support@cloud.gov</a>
             <a href="mailto:cloud-gov-support@gsa.gov">cloud-gov-support@gsa.gov</a>.
         </p>
         <p>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update reset password email template with explicit steps and link to docs

## security considerations
None.  

Related to https://github.com/cloud-gov/product/issues/1386
