### PR TITLE
Update CSV parsing to correctly read file

### DIFF
--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -264,9 +264,8 @@ def create_app(env=os.environ):
     #   https://raw.githubusercontent.com/GSA/data/master/dotgov-domains/current-federal.csv
     # and place into 'static' dir
     domain_list = [".mil"]
-    with open(
-        os.path.join(app.config["APP_STATIC"], "current-federal.csv"), newline=""
-    ) as fed_gov_csv:
+    csv_path = os.path.join(app.config["APP_STATIC"], "current-federal.csv")
+    with open(csv_path, newline='', encoding='utf-8') as fed_gov_csv:
         for row in csv.reader(fed_gov_csv):
             domain_list.append(row[0].strip().rstrip().lower())
     app.config["VALID_FED_DOMAINS"] = tuple(domain_list)


### PR DESCRIPTION
The encoding format of the CSV files we use for checking valid government domains recently changed to UTF-8.  This changeset updates our CSV parsing to correctly open the file for parsing, and makes the code a bit more readable as well.

h/t to @ChrisMcGowan and @bengerman13 for tracking this down!

## Changes proposed in this pull request:
- Update how the CSV file is opened to account for UTF-8 encoding
- Small tweak in code readability

## security considerations
- None; no changes are made to how the file is parsed