### PR TITLE
update email addresses, description, and urls

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,6 +38,7 @@ jobs:
         UAA_SECRET: ((uaa-client-secret-development))
         UAA_URL: ((uaa-base-url-development))
         IDP_URL: ((idp-base-url-development))
+        UAA_TARGET: ((uaa-target-url-development))
         EXTRAS_URL: ((uaa-extras-url-development))
         IDP_NAME: ((idp-provider-origin-development))
   on_failure:
@@ -99,6 +100,7 @@ jobs:
         UAA_SECRET: ((uaa-client-secret-staging))
         UAA_URL: ((uaa-base-url-staging))
         IDP_URL: ((idp-base-url-staging))
+        UAA_TARGET: ((uaa-target-url-staging))
         EXTRAS_URL: ((uaa-extras-url-staging))
         IDP_NAME: ((idp-provider-origin-staging))
   on_failure:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -185,7 +185,7 @@ resources:
   type: git
   source:
     uri: ((cg-uaa-extras-git-url))
-    branch: ((cg-uaa-exras-git-branch))
+    branch: ((cg-uaa-extras-git-branch))
 
 - name: cloud-gov-development
   type: cf

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -185,7 +185,7 @@ resources:
   type: git
   source:
     uri: ((cg-uaa-extras-git-url))
-    branch: master
+    branch: ((cg-uaa-exras-git-branch))
 
 - name: cloud-gov-development
   type: cf

--- a/uaaextras/templates/email/body.html
+++ b/uaaextras/templates/email/body.html
@@ -11,7 +11,7 @@
             <a href="https://cloud.gov">{{branding.company_name}} [1]</a>.
         </p>
         <p>
-            {{branding.company_name}} is a service by 18F that helps federal teams create and deliver quality digital services securely hosted in the cloud.
+            {{branding.company_name}} is a secure and compliant Platform as a Service (PaaS). cloud.gov helps federal agencies deliver the services the public deserves in a faster, more user-centered way.
         </p>
         <strong>Your next steps</strong>
         <p>
@@ -25,7 +25,7 @@
               <strong>Read the documentation</strong> - After you register and log in, review the <a href="https://cloud.gov/docs/getting-started/accounts/#use-your-account-responsibly">acceptable uses and rules of behavior [3]</a>.
             </li>
             <li>
-            If you signed up for a trial space (a sandbox), <strong>make sure you understand the <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/#to-keep-in-mind-before-you-try-your-sandbox">sandbox policies and restrictions [4]</a></strong>.
+            If you signed up for a trial space (a sandbox), <strong>make sure you understand the <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/#keep-in-mind-before-you-try-your-sandbox">sandbox policies and restrictions [4]</a></strong>.
             </li>
             <li>
             <strong>Then <a href="https://cloud.gov/docs/getting-started/setup/">set up your access and get started [5]</a></strong>.
@@ -33,7 +33,7 @@
         </ol>
         </p>
         <p>
-            If you run into problems or have any questions, please email us at <a href="mailto:cloud-gov-support@gsa.gov">cloud-gov-support@gsa.gov</a>.
+            If you run into problems or have any questions, please email us at <a href="mailto:support@cloud.gov">support@cloud.gov</a>.
         </p>
         <p>
             Thank you,<br />
@@ -44,7 +44,7 @@
             <li>[1] {{branding.company_name}}: https://cloud.gov</li>
             <li>[2] Accept your invite: {{verification_url}}</li>
             <li>[3] Acceptable uses and rules of behavior: https://cloud.gov/docs/getting-started/accounts/#use-your-account-responsibly</li>
-            <li>[4] Sandbox policies and restrictions: https://cloud.gov/overview/pricing/free-limited-sandbox/#to-keep-in-mind-before-you-try-your-sandbox</li>
+            <li>[4] Sandbox policies and restrictions: https://cloud.gov/overview/pricing/free-limited-sandbox/#keep-in-mind-before-you-try-your-sandbox</li>
             <li>[5] Set up your access and get started: https://cloud.gov/docs/getting-started/setup/</li>
         </ul>
     </body>

--- a/uaaextras/templates/error/token_validation.html
+++ b/uaaextras/templates/error/token_validation.html
@@ -5,6 +5,6 @@
 	<h2>Unable to validate your login request</h2>
 	<p>If you just tried to use an invitation, it may have expired. You can <a href="{{url_for('signup')}}">invite yourself again</a>.</p>
 	<p>If you tried to log into a cloud.gov customer application that uses cloud.gov authentication, it may have an issue. Ask the application maintainer to check its configuration.</p>
-	<p>If something else went wrong, <a href="{{url_for('logout')}}">log out and try again</a> or email <a href="mailto:cloud-gov-support@gsa.gov">cloud-gov-support@gsa.gov</a>.</p>
+	<p>If something else went wrong, <a href="{{url_for('logout')}}">log out and try again</a> or email <a href="mailto:support@cloud.gov">support@cloud.gov</a>.</p>
 </div>
 {% endblock %}

--- a/uaaextras/templates/signup.html
+++ b/uaaextras/templates/signup.html
@@ -13,8 +13,8 @@
   <div>
      <p>Still interested in using cloud.gov?</p>
      <p>
-	If you work with a person who has access to cloud.gov, ask them to <a href="https://cloud.gov/docs/apps/managing-teammates/">send you an invitation</a>.
-	Otherwise, <a href="https://cloud.gov/overview/overview/who-can-use-cloudgov/">learn more about whether you can use cloud.gov</a>.
+	If you work with a person who has access to cloud.gov, ask them to <a href="https://cloud.gov/docs/orgs-spaces/roles/">send you an invitation</a>.
+	Otherwise, <a href="https://cloud.gov/docs/overview/who-can-use-cloudgov/">learn more about whether you can use cloud.gov</a>.
      </p>
   </div>
 {% endif %}
@@ -27,6 +27,6 @@
         <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
      </form>
 </div>
-<p style="max-width: 350px;">People with U.S. federal government email addresses can get access to a <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/">free sandbox space</a>. The sandbox gives you a limited way to try the service. Others must be invited to collaborate by existing cloud.gov users. </p>
-<p style="max-width: 350px;">Learn more about <a href="https://cloud.gov/overview/overview/who-can-use-cloudgov/">who can use cloud.gov</a> and <a href="https://cloud.gov/docs/apps/managing-teammates/">how existing users can invite you to collaborate on their projects</a>.
+<p style="max-width: 350px;">People with U.S. federal government email addresses can get access to a <a href="https://cloud.gov/docs/pricing/free-limited-sandbox/">free sandbox space</a>. The sandbox gives you a limited way to try the service. Others must be invited to collaborate by existing cloud.gov users. </p>
+<p style="max-width: 350px;">Learn more about <a href="https://cloud.gov/docs/overview/who-can-use-cloudgov/">who can use cloud.gov</a> and <a href="https://cloud.gov/docs/orgs-spaces/roles/">how existing users can invite you to collaborate on their projects</a>.
 {% endblock %}


### PR DESCRIPTION
## Changes proposed in this pull request:
- update to current email address
- update urls to reduce redirects
- update cloud.gov description. This is what prompted the change, and the part I'm least sure about. Since we're no longer an 18F product, talking about 18F in our emails feels weird. I yanked this description from our website, but I'm not 100% sure it's the right verbiage to use here.

## security considerations
None