### PR TITLE
Update Redis configuration to use new service

### DIFF
--- a/manifest_production_fr_uaaextra.yml
+++ b/manifest_production_fr_uaaextra.yml
@@ -7,6 +7,6 @@ applications:
   stack: cflinuxfs3
   instances: 2
   services:
-  - redis-accounts
+  - redis-accounts-aws
   env:
     ENV: production

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -20,3 +20,4 @@ applications:
   #  BRANDING_COMPANY_NAME: Testoku
   #  IDP_PROVIDER_ORIGIN: my.idp.com
   #  IDP_PROVIDER_URL: https://idp.bosh-lite.com
+  #  MAINTENANCE_MODE: False

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -5,7 +5,7 @@ applications:
   buildpack: python_buildpack
   stack: cflinuxfs3
   services:
-  - redis-accounts
+  - redis-accounts-aws
   env:
     ENV: production
   #  UAA_BASE_URL: https://uaa.bosh-lite.com

--- a/uaaextras/templates/maintenance.html
+++ b/uaaextras/templates/maintenance.html
@@ -1,0 +1,11 @@
+{% extends "_layout.html" %}
+
+{% block header %}System Maintenance{% endblock %}
+
+{% block content %}
+<div class="island-content">
+    <p>Our system is currently undergoing scheduled maintenance and will be back online soon.</p>
+
+    <p>We're sorry for any inconvenience.  Please check the <a href="https://cloudgov.statuspage.io/">cloud.gov StatusPage</a> for updates.</p>
+</div>
+{% endblock %}

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -60,7 +60,7 @@ redis_env = dict(host="localhost", port=6379, password="")
 # Get Redis credentials
 if "VCAP_SERVICES" in os.environ:
     services = json.loads(os.getenv("VCAP_SERVICES"))
-    redis_info = services["redis32"][0]["credentials"]
+    redis_info = services["aws-elasticache-redis"][0]["credentials"]
 
     redis_env = {
         "host": redis_info["hostname"],
@@ -68,10 +68,12 @@ if "VCAP_SERVICES" in os.environ:
         "password": redis_info["password"],
         "socket_timeout": 0.5,
         "socket_connect_timeout": 0.5,
+        "ssl": True,
+        "ssl_cert_reqs": None,
     }
 
 # Connect to redis
-r = redis.StrictRedis(**redis_env)
+r = redis.Redis(**redis_env)
 
 uaadb_engine = create_engine(os.getenv("UAADB_CONNECTION_STRING", "sqlite:///:memory:"))
 


### PR DESCRIPTION
This changeset modifies our Redis configuration to use the new ElastiCache service (AWS Redis).

## Changes proposed in this pull request:
- Updates service binding to the new Redis service
- Updates the Redis config to enable TLS support for secure connections
- Updates the Redis config based on [recent redis-py updates](https://github.com/andymccurdy/redis-py#ssl-connections)

## security considerations:
- Makes uaa-extras more secure by using TLS connections with Redis
- Updates our internal service use to more modern implementations