### PR TITLE
fix tests for new uaa token check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
         "psycopg2==2.8.6",
     ],
     test_suite="uaaextras.tests",
-    tests_require=["blinker", "httmock", "mock"],
+    tests_require=["blinker", "httmock", "mock", "requests_mock"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,10 @@
 [tox]
-envlist = py38,report
+envlist = py38
 
 [testenv]
 basepython = python3.8
 commands =
-  coverage erase
-  coverage run -a setup.py test
-deps =
-  coverage
-
-[testenv:report]
-basepython = python3.8
-commands =
-  coverage report --include="*uaaextras*" --omit="*tests*"
-  coverage html --include="*uaaextras*" --omit="*tests*"
+  python setup.py test
 
 [testenv:flake8]
 basepython = python3.8

--- a/uaaextras/clients/uaa.py
+++ b/uaaextras/clients/uaa.py
@@ -466,16 +466,15 @@ class UAAClient(object):
         )
 
 
-    def check_token_valid(self, maybe_valid_token, client_id, client_secret) -> bool:
+    def check_token_valid(self, maybe_valid_token) -> bool:
         """
         Check whether the provided token is valid, using the client_id and client_secret to authenticate
         """
-        our_token = self._get_client_token(client_id, client_secret)
         headers = {
-            "Authorization": f"bearer {our_token}",
+            "Authorization": f"bearer {maybe_valid_token}",
         }
         url = urljoin(self.base_url.rstrip("/"), "/introspect".lstrip("/"))
         response = requests.post(url, data={"token": maybe_valid_token}, headers=headers)
         if response.status_code != 200:
-            raise UAAError(response)
+            return False
         return response.json().get("active", False)

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -311,6 +311,7 @@ def create_app(env=os.environ):
             "reset_password",
             "signup",
             "static",
+            "logout",
         ]:
             return
 
@@ -322,15 +323,19 @@ def create_app(env=os.environ):
                 None,
                 verify_tls=app.config["UAA_VERIFY_TLS"],
             )
+        
+        has_valid_token = False
 
         # if all looks good, setup the client
-        if token and token_checking_client.check_token_valid(token, app.config["CLIENT_ID"], app.config["CLIENT_SECRET"]):
+        if token:
             g.uaac = UAAClient(
                 app.config["UAA_BASE_URL"],
-                session["UAA_TOKEN"],
+                token,
                 verify_tls=app.config["UAA_VERIFY_TLS"],
             )
-        else:
+            has_valid_token = g.uaac.check_token_valid(token)
+
+        if not has_valid_token:
             # if not forget the token, it's bad (if we have one)
             session.clear()
             session["_endpoint"] = request.endpoint


### PR DESCRIPTION
## Changes proposed in this pull request:
- mock introspect endpoint
- remove coverage check because it's just clutter
- add test for bad token
- add logout to safe endpoints

I'm not 100% sure about adding the logout to the safe endpoints list. I'm trying to avoid a weird experience where you try to log out when your token is invalid, and are forced back through the login endpoint and end up logging in and being redirected to the logout and ....

## security considerations
None