### PR TITLE
Find versions

### DIFF
--- a/ci/integration_test.yml
+++ b/ci/integration_test.yml
@@ -4,7 +4,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: 18fgsa/concourse-task
+    repository: python
+    tag: 3.10
 
 inputs:
   - name: uaa-extras-integrated

--- a/ci/integration_test.yml
+++ b/ci/integration_test.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: python
-    tag: 3.10
+    tag: '3.10'
 
 inputs:
   - name: uaa-extras-integrated

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,9 +2,5 @@
 
 set -ex
 
-apt update
-apt install -y libpq-dev
-
-pyenv install -s $(cat ./cg-uaa-extras-app/.python-version)
 pip install tox
 (cd ./cg-uaa-extras-app && tox)

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: themattrix/tox-base
+    repository: "python:3.10"
 
 inputs:
   - name: cg-uaa-extras-app

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -4,7 +4,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: "python:3.10"
+    repository: python
+    tag: 3.10
 
 inputs:
   - name: cg-uaa-extras-app

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: python
-    tag: 3.10
+    tag: '3.10'
 
 inputs:
   - name: cg-uaa-extras-app

--- a/integration_tests/run_integration_tests.sh
+++ b/integration_tests/run_integration_tests.sh
@@ -24,6 +24,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")"
         python3 -m pip install -r requirements.txt
 
         pushd ../
+            python3 -m pip install -r requirements.txt
             python3 setup.py install
         popd
     fi

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -7,3 +7,4 @@ cloudfoundry-client
 gunicorn
 itsdangerous<=2.0.1 # pinning for import error
 email_validator
+psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,6 +63,8 @@ polling2==0.5.0
     # via cloudfoundry-client
 protobuf==3.19.4
     # via cloudfoundry-client
+psycopg2==2.9.3
+    # via -r pip-tools/requirements.in
 pyparsing==3.0.7
     # via packaging
 pyyaml==6.0


### PR DESCRIPTION
## Changes proposed in this pull request:
- last one, I think
- switch to official python image. This is ugly and a PITA for now, since we now have 3 places to update our version when it changes. We should create our own pyenv image later, but this is enough to unblock for now
- add requirements.txt into integration test installation

## security considerations
Better to use a main