### PR TITLE
setuptools needed to be added to requirements.txt instead of pip-tool…

### DIFF
--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -7,5 +7,4 @@ cloudfoundry-client
 gunicorn
 itsdangerous<=2.0.1 # pinning for import error
 email_validator
-setuptools==65.1.1
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,8 @@ six==1.16.0
     #   websocket-client
 sqlalchemy==1.4.31
     # via -r pip-tools/requirements.in
+setuptools==65.1.1
+    # via fix for bug in Python Buildpack - should be removed when a compatible Bosh release is deployed
 talisman==0.1.0
     # via -r pip-tools/requirements.in
 urllib3==1.26.8


### PR DESCRIPTION
…s/requirements.in as requirements.txt is not correctly updated otherwise

## Changes proposed in this pull request:
- moved the setuptools pinning from requirements.in to requirements.txt as it is not correctly generated


## security considerations
None as this is moving a package installation