### PR TITLE
Update setuptools version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,3 @@ commands =
 basepython = python3.10
 deps = flake8
 commands = flake8
-
-[pytest]
-env_files =
-    .env

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,6 @@ basepython = python3.10
 deps = flake8
 commands = flake8
 
+[pytest]
+env_files =
+    .env

--- a/uaaextras/tests/test_webapp.py
+++ b/uaaextras/tests/test_webapp.py
@@ -565,7 +565,7 @@ class TestAppConfig(unittest.TestCase):
                 sess["_csrf_token"] = "baz"
 
             rv = c.post(
-                "/signup", data={"email": "example@fs.fed.us", "_csrf_token": "baz"}
+                "/signup", data={"email": "example@nmcourt.fed.us", "_csrf_token": "baz"}
             )
             assert rv.status_code == 200
             render_template.assert_called_with("signup_invite_sent.html")


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pinned setuptools version to make the Python buildpack happy - this may eventually be updated to latest instead once we verify the buildpack has the correct version in it
- Removed the line after the flake8 config in tox.ini per python standards (no blank line at the end of a file)
- Updated test_signup_good to use a working domain for testing

## security considerations
No changes in security were made, so no considerations