### PR TITLE
updated manifest one more time to fix deprecated attributes

### DIFF
--- a/manifest_production_fr_uaaextra.yml
+++ b/manifest_production_fr_uaaextra.yml
@@ -1,8 +1,8 @@
 ---
 applications:
 - name: uaaextra
-  host: account
-  domain: fr.cloud.gov
+  routes:
+  - route: account.fr.cloud.gov
   buildpacks:
   - python_buildpack
   stack: cflinuxfs3


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated the attributes based on deprecation errors from CF, this involved removing domain and host in favor of routes with the FQDN as its value

## security considerations
None as this doesn't change the security posture
