### PR TITLE
Verify cflinuxfs4

### DIFF
--- a/manifest_production_fr_uaaextra.yml
+++ b/manifest_production_fr_uaaextra.yml
@@ -5,7 +5,6 @@ applications:
   - route: account.fr.cloud.gov
   buildpacks:
   - python_buildpack
-  stack: cflinuxfs3
   instances: 2
   services:
   - redis-accounts-aws

--- a/manifest_production_fr_uaaextra.yml
+++ b/manifest_production_fr_uaaextra.yml
@@ -5,6 +5,7 @@ applications:
   - route: account.fr.cloud.gov
   buildpacks:
   - python_buildpack
+  stack: cflinuxfs3
   instances: 2
   services:
   - redis-accounts-aws

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -3,7 +3,6 @@ applications:
 - name: uaaextra
   buildpacks:
   - python_buildpack
-  stack: cflinuxfs3
   services:
   - redis-accounts-aws
   routes:

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -3,7 +3,6 @@ applications:
 - name: uaaextra
   buildpacks:
   - python_buildpack
-  stack: cflinuxfs4
   services:
   - redis-accounts-aws
   routes:

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -3,7 +3,7 @@ applications:
 - name: uaaextra
   buildpacks:
   - python_buildpack
-  stack: cflinuxfs3
+  stack: cflinuxfs4
   services:
   - redis-accounts-aws
   routes:

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -3,6 +3,7 @@ applications:
 - name: uaaextra
   buildpacks:
   - python_buildpack
+  stack: cflinuxfs3
   services:
   - redis-accounts-aws
   routes:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removed stack from both prod and staging manifests so the cflinuxfs will assume the platform default

## security considerations
None as this is removing a config item that overrides the platform default and has no effect on security