### PR TITLE
Set colorama version

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-pip install tox
+pip install tox colorama==0.4.4
 (cd ./cg-uaa-extras-app && tox)

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,5 +2,6 @@
 
 set -ex
 
-pip install tox colorama==0.4.4
-(cd ./cg-uaa-extras-app && tox)
+cd ./cg-uaa-extras-app
+pip install -r requirements-ci.txt
+tox

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,2 @@
+tox
+colorama==0.4.4


### PR DESCRIPTION
## Changes proposed in this pull request:
- Set colorama to specific version so tox can run
-
-

## security considerations
Sets dependency for python package
