### PR TITLE
Email username verification

### DIFF
--- a/uaaextras/tests/test_validators.py
+++ b/uaaextras/tests/test_validators.py
@@ -1,6 +1,6 @@
 import unittest
 
-from uaaextras.validators import host_valid_for_domain, email_valid_for_domains
+from uaaextras.validators import host_valid_for_domain, email_valid_for_domains, email_username_valid
 
 class TestHostValidator(unittest.TestCase):
 
@@ -21,3 +21,14 @@ class TestHostValidator(unittest.TestCase):
         assert not email_valid_for_domains("me@aexample.com", ["a.example.com", "b.example.com"])
         assert not email_valid_for_domains("me@example.com", ["a.example.com", "b.example.com"])
         assert not email_valid_for_domains("me@aexample.com", ["example.com"])
+
+
+    def test_email_username_validator(self):
+        assert email_username_valid("me@example.com")
+        assert email_username_valid("me@gsa.com")
+        assert email_username_valid("me@tts.gsa.gov")
+        assert email_username_valid("me.last@gsa.gov")
+        assert email_username_valid("me1.last1@gsa.gov")
+        assert not email_username_valid("me?.last1@gsa.gov")
+        assert not email_username_valid("me.last1@gsa.g")
+        assert not email_username_valid("=?x?q?hwhaqti69r1ppe=40toasty.com=3e=1f?=foo@gsa.gov")

--- a/uaaextras/tests/test_validators.py
+++ b/uaaextras/tests/test_validators.py
@@ -31,4 +31,4 @@ class TestHostValidator(unittest.TestCase):
         assert email_username_valid("me1.last1@gsa.gov")
         assert not email_username_valid("me?.last1@gsa.gov")
         assert not email_username_valid("me.last1@gsa.g")
-        assert not email_username_valid("=?x?q?hwhaqti69r1ppe=40toasty.com=3e=1f?=foo@gsa.gov")
+        assert not email_username_valid("=?x?q?hwhaqti69r1ppe=40example.gov=3e=1f?=foo@gsa.gov")

--- a/uaaextras/validators.py
+++ b/uaaextras/validators.py
@@ -1,4 +1,4 @@
-
+import re
 
 def email_valid_for_domains(address, domains):
     """
@@ -13,3 +13,9 @@ def host_valid_for_domain(host, domain):
     host_parts = host.split('.')
     overlap = host_parts[-1*len(valid_parts):]
     return overlap == valid_parts
+
+def email_username_valid(email):
+    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    if re.match(pattern, email):
+        return True
+    return False

--- a/uaaextras/validators.py
+++ b/uaaextras/validators.py
@@ -16,6 +16,4 @@ def host_valid_for_domain(host, domain):
 
 def email_username_valid(email):
     pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-    if re.match(pattern, email):
-        return True
-    return False
+    return re.match(pattern, email):

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -9,7 +9,6 @@ import redis
 import smtplib
 import ssl
 import uuid, string, random, json
-import re
 
 from flask import Flask, flash, g, redirect, render_template, request, session, url_for
 from markupsafe import Markup
@@ -19,6 +18,7 @@ from zxcvbn import zxcvbn
 
 from uaaextras.clients import UAAClient, UAAError, TOTPClient, CFClient
 from uaaextras.validators import email_valid_for_domains
+from uaaextras.validators import email_username_valid
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
@@ -450,8 +450,7 @@ def create_app(env=os.environ):
             return render_template("signup.html")
         
         # Check the username pattern is valid, a-z, numbers and a select set of special characters
-        pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-        if not re.match(pattern, email):
+        if not email_username_valid(email):
             flash(
                 "This does not seem to be a valid username for U.S. federal government email addresses. "
                 "Self-service invitations are only offered for U.S. federal government email addresses. "
@@ -459,7 +458,6 @@ def create_app(env=os.environ):
                 "cloud-gov-inquiries@gsa.gov to let us know to whitelist your email address."
             )
             return render_template("signup.html")
-
 
         # Check for feds here
         if not email_valid_for_domains(email, app.config["VALID_FED_DOMAINS"]):

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -9,6 +9,7 @@ import redis
 import smtplib
 import ssl
 import uuid, string, random, json
+import re
 
 from flask import Flask, flash, g, redirect, render_template, request, session, url_for
 from markupsafe import Markup
@@ -447,6 +448,19 @@ def create_app(env=os.environ):
             # email is not valid, exception message is human-readable
             flash(str(exc))
             return render_template("signup.html")
+        
+        # Check the username pattern is valid, a-z, numbers and a select set of special characters
+        pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        if not re.match(pattern, email):
+            flash(
+                "This does not seem to be a valid username for U.S. federal government email addresses. "
+                "Self-service invitations are only offered for U.S. federal government email addresses. "
+                "If you do have a valid U.S. federal government email address, email us at "
+                "cloud-gov-inquiries@gsa.gov to let us know to whitelist your email address."
+            )
+            return render_template("signup.html")
+
+
         # Check for feds here
         if not email_valid_for_domains(email, app.config["VALID_FED_DOMAINS"]):
             flash(


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add extra validation to username of the email address
- Should only accept a-z, 0-9, %, +, -, and period, should end with at least two characters
-

## security considerations
Attempting to reduce the number of uaa users attempting to create accounts from automated security scans
